### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php":                            ">=5.3.2",
-        "symfony/symfony":                ">=2.0.0-dev"
+        "symfony/http-foundation":        ">=2.0.0-dev"
     },
     "autoload": {
         "psr-0": { "FOS\\Rest": "" }


### PR DESCRIPTION
The FOSRest lib requires only the http-foundation component not all symfony2
