### PR TITLE
Complete HTTP status code list

### DIFF
--- a/Util/Codes.php
+++ b/Util/Codes.php
@@ -14,12 +14,20 @@ namespace FOS\Rest\Util;
 /**
  * List of HTTP response status codes.
  *
+ * The list of codes is complete according to the
+ * {@link http://www.iana.org/assignments/http-status-codes/ Hypertext Transfer Protocol (HTTP) Status Code Registry}
+ * (last updated 2012-02-13).
+ *
+ * Unless otherwise noted, the status code is defined in RFC2616.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Markus Lanthaler <markus.lanthaler@gmx.net>
  */
 class Codes
 {
     const HTTP_CONTINUE = 100;
     const HTTP_SWITCHING_PROTOCOLS = 101;
+    const HTTP_PROCESSING = 102;            // RFC2518
     const HTTP_OK = 200;
     const HTTP_CREATED = 201;
     const HTTP_ACCEPTED = 202;
@@ -27,12 +35,16 @@ class Codes
     const HTTP_NO_CONTENT = 204;
     const HTTP_RESET_CONTENT = 205;
     const HTTP_PARTIAL_CONTENT = 206;
+    const HTTP_MULTI_STATUS = 207;          // RFC4918
+    const HTTP_ALREADY_REPORTED = 208;      // RFC5842
+    const HTTP_IM_USED = 226;               // RFC3229
     const HTTP_MULTIPLE_CHOICES = 300;
     const HTTP_MOVED_PERMANENTLY = 301;
     const HTTP_FOUND = 302;
     const HTTP_SEE_OTHER = 303;
     const HTTP_NOT_MODIFIED = 304;
     const HTTP_USE_PROXY = 305;
+    const HTTP_RESERVED = 306;
     const HTTP_TEMPORARY_REDIRECT = 307;
     const HTTP_BAD_REQUEST = 400;
     const HTTP_UNAUTHORIZED = 401;
@@ -52,10 +64,23 @@ class Codes
     const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
     const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
     const HTTP_EXPECTATION_FAILED = 417;
+    const HTTP_UNPROCESSABLE_ENTITY = 422;  // RFC4918
+    const HTTP_LOCKED = 423;                // RFC4918
+    const HTTP_FAILED_DEPENDENCY = 424;     // RFC4918
+    const HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL = 425;   // RFC2817
+    const HTTP_UPGRADE_REQUIRED = 426;      // RFC2817
+    const HTTP_PRECONDITION_REQUIRED = 428; // RFC-nottingham-http-new-status-04
+    const HTTP_TOO_MANY_REQUESTS = 429;     // RFC-nottingham-http-new-status-04
+    const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;   // RFC-nottingham-http-new-status-04
     const HTTP_INTERNAL_SERVER_ERROR = 500;
     const HTTP_NOT_IMPLEMENTED = 501;
     const HTTP_BAD_GATEWAY = 502;
     const HTTP_SERVICE_UNAVAILABLE = 503;
     const HTTP_GATEWAY_TIMEOUT = 504;
     const HTTP_VERSION_NOT_SUPPORTED = 505;
+    const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL = 506;  // [RFC2295]
+    const HTTP_INSUFFICIENT_STORAGE = 507;  // RFC4918
+    const HTTP_LOOP_DETECTED = 508;         // RFC5842
+    const HTTP_NOT_EXTENDED = 510;          // RFC2774
+    const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;   // RFC-nottingham-http-new-status-04
 }


### PR DESCRIPTION
Updated the HTTP response status code constants to include all HTTP status codes as defined by the IANA Hypertext Transfer Protocol (HTTP) Status Code Registry (http://www.iana.org/assignments/http-status-codes/).

@lsmith77 [asked me](https://github.com/symfony/symfony/pull/3548#issuecomment-4430936) to create a this PR.
