### PR TITLE
Add JSON to form format decoder

### DIFF
--- a/Decoder/JsonToFormDecoder.php
+++ b/Decoder/JsonToFormDecoder.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\Rest\Decoder;
+
+use FOS\Rest\Decoder\DecoderInterface;
+
+/**
+ * Decodes JSON data and make it compliant with application/x-www-form-encoded style
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class JsonToFormDecoder implements DecoderInterface
+{
+
+    /**
+     * Makes data decoded from JSON application/x-www-form-encoded compliant 
+     * 
+     * @param array $data
+     */
+    private function xWwwFormEncodedLike(&$data)
+    {
+        foreach ($data as $key => &$value) {
+            if (is_array($value)) {
+                // Encode recursively
+                $this->xWwwFormEncodedLike($value);
+            } elseif (false === $value) {
+                // Checkbox-like behavior: remove false data
+                unset($data[$key]);
+            } elseif (!is_string($value)) {
+                // Convert everyting to string
+                // true values will be converted to '1', this is the default checkbox behavior
+                $value = strval($value);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decode($data)
+    {
+        $decodedData = @json_decode($data, true);
+        if ($decodedData) {
+            $this->xWwwFormEncodedLike($decodedData);
+        }
+
+        return $decodedData;
+    }
+
+}

--- a/Tests/Decoder/JsonToFormDecoderTest.php
+++ b/Tests/Decoder/JsonToFormDecoderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\Rest\Tests\Decoder;
+
+use FOS\Rest\Decoder\JsonToFormDecoder;
+
+/**
+ * Tests the form like encoder
+ * 
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class JsonToFormDecoderTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testDecode()
+    {
+        $data = array(
+            'arrayKey' => array(
+                'falseKey' => false,
+                'stringKey' => 'foo'
+            ),
+            'falseKey' => false,
+            'trueKey' => true,
+            'intKey' => 69,
+            'floatKey' => 3.14,
+            'stringKey' => 'bar',
+        );
+        $decoder = new JsonToFormDecoder();
+        $decoded = $decoder->decode(json_encode($data));
+
+        $this->assertTrue(is_array($decoded));
+        $this->assertTrue(is_array($decoded['arrayKey']));
+        $this->assertArrayNotHasKey('falseKey', $decoded['arrayKey']);
+        $this->assertEquals('foo', $decoded['arrayKey']['stringKey']);
+        $this->assertArrayNotHasKey('falseKey', $decoded);
+        $this->assertEquals('1', $decoded['trueKey']);
+        $this->assertEquals('69', $decoded['intKey']);
+        $this->assertEquals('3.14', $decoded['floatKey']);
+        $this->assertEquals('bar', $decoded['stringKey']);
+    }
+
+}


### PR DESCRIPTION
Converts JSON data to application/x-www-form-encoded compliant format.
Allo to use default Symfony's form framework widgets for JSON REST API.
- Unset `false` data to act like a checkbox
- Cast all non-string data to `string` like the default PHP behavior for `$_` superglobals.

See for usage example: https://github.com/dunglas/DunglasTodoMVCBundle/blob/master/Controller/TodoController.php
