### PR TITLE
Do not return highest priority format immediately when catch-all is dete...

### DIFF
--- a/Util/FormatNegotiator.php
+++ b/Util/FormatNegotiator.php
@@ -75,7 +75,8 @@ class FormatNegotiator implements FormatNegotiatorInterface
         foreach ($keys as $mimetype) {
             unset($mimetypes[$mimetype]);
             if ($mimetype === '*/*') {
-                return reset($priorities);
+                $catchAllMatched = true;
+                continue;
             }
             $format = $request->getFormat($mimetype);
             if ($format) {
@@ -86,6 +87,10 @@ class FormatNegotiator implements FormatNegotiatorInterface
                     $formats[$format] = count($priorities);
                 }
             }
+        }
+
+        if (empty($formats) && $catchAllMatched) {
+            return reset($priorities);
         }
 
         if (empty($formats) && !empty($mimetypes)) {

--- a/Util/FormatNegotiator.php
+++ b/Util/FormatNegotiator.php
@@ -72,6 +72,7 @@ class FormatNegotiator implements FormatNegotiatorInterface
         $keys = array_keys($mimetypes, $max);
 
         $formats = array();
+        $catchAllMatched = false;
         foreach ($keys as $mimetype) {
             unset($mimetypes[$mimetype]);
             if ($mimetype === '*/*') {


### PR DESCRIPTION
...cted

Related to issue 372 of FOSRestBundle: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/372

From the HTTP/1.1 spec (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html):

Media ranges can be overridden by more specific media ranges or specific media types. If more than one media range applies to a given type, the most specific reference has precedence. For example,

```
   Accept: text/*, text/html, text/html;level=1, */*
```

have the following precedence:

```
   1) text/html;level=1
   2) text/html
   3) text/*
   4) */*
```
